### PR TITLE
Implements the proposed modifications from /u/akeniscool, with static methods to create immutable objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use FlameCore\UserAgent\UserAgent;
 require 'vendor/autoload.php';
 
 // Create a user agent object
-$userAgent = new UserAgent();
+$userAgent = UserAgent::createFromGlobal();
 ```
 
 Then the parsed values can be retrieved using the getter methods:
@@ -51,13 +51,13 @@ When you create a `UserAgent` object, the current user agent string is used. You
 
 ``` php
 // Use another User Agent string
-$userAgent = new UserAgent('msnbot/2.0b (+http://search.msn.com/msnbot.htm)');
+$userAgent = UserAgent::create('msnbot/2.0b (+http://search.msn.com/msnbot.htm)');
 $userAgent->getBrowserName(); // msnbot
 
 // Use current User Agent string
-$userAgent = new UserAgent($_SERVER['HTTP_USER_AGENT']);
+$userAgent = UserAgent::create($_SERVER['HTTP_USER_AGENT']);
 // ... which is equivalent to:
-$userAgent = new UserAgent();
+$userAgent = UserAgent::createFromGlobal();
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Create a file called `composer.json` in your project directory and put the follo
 ```
 {
     "require": {
-        "flamecore/user-agent": "1.0.*"
+        "flamecore/user-agent": "dev-master"
     }
 }
 ```

--- a/lib/UserAgent.php
+++ b/lib/UserAgent.php
@@ -270,7 +270,8 @@ class UserAgent
             'maxthon',
             'konqueror',
             'netscape',
-            'lynx'
+            'lynx',
+            'links'
         );
     }
 

--- a/lib/UserAgent.php
+++ b/lib/UserAgent.php
@@ -59,9 +59,31 @@ class UserAgent
      * @param string $string The user agent string. Uses the current User Agent string by default.
      * @param \FlameCore\UserAgent\UserAgentStringParser $parser The parser used to parse the string
      */
-    public function __construct($string = null, UserAgentStringParser $parser = null)
+    private function __construct($string = null, UserAgentStringParser $parser = null)
     {
         $this->configureFromUserAgentString($string, $parser);
+    }
+
+    /**
+     * Creates a UserAgent object from the global $_SERVER string.
+     *
+     * @return UserAgent The user agent object.
+     */
+    public static function createFromGlobal()
+    {
+        return new self($_SERVER['HTTP_USER_AGENT']);
+    }
+
+    /**
+     * Creates a UserAgent object.
+     *
+     * @param string $string The user agent string. Uses the current User Agent string by default.
+     * @param \FlameCore\UserAgent\UserAgentStringParser $parser The parser used to parse the string
+     * @return UserAgent The user agent object.
+     */
+    public static function create($string = null, UserAgentStringParser $parser = null)
+    {
+        return new self($string, $parser);
     }
 
     /**
@@ -89,7 +111,7 @@ class UserAgent
      *
      * @param string $string The user agent string
      */
-    public function setUserAgentString($string)
+    private function setUserAgentString($string)
     {
         $this->string = $string;
     }
@@ -105,16 +127,6 @@ class UserAgent
     }
 
     /**
-     * Sets the browser name.
-     *
-     * @param string $name The browser name
-     */
-    public function setBrowserName($name)
-    {
-        $this->browserName = $name;
-    }
-
-    /**
      * Gets the browser version.
      *
      * @return string
@@ -122,16 +134,6 @@ class UserAgent
     public function getBrowserVersion()
     {
         return $this->browserVersion;
-    }
-
-    /**
-     * Sets the browser version.
-     *
-     * @param string $version The browser version
-     */
-    public function setBrowserVersion($version)
-    {
-        $this->browserVersion = $version;
     }
 
     /**
@@ -155,16 +157,6 @@ class UserAgent
     }
 
     /**
-     * Sets the browser engine name.
-     *
-     * @param string $browserEngine The browser engine name
-     */
-    public function setBrowserEngine($browserEngine)
-    {
-        $this->browserEngine = $browserEngine;
-    }
-
-    /**
      * Gets the operating system name.
      *
      * @return string
@@ -175,16 +167,6 @@ class UserAgent
     }
 
     /**
-     * Sets the operating system name.
-     *
-     * @param string $operatingSystem The operating system name
-     */
-    public function setOperatingSystem($operatingSystem)
-    {
-        $this->operatingSystem = $operatingSystem;
-    }
-
-    /**
      * Gets the device name.
      *
      * @return string
@@ -192,16 +174,6 @@ class UserAgent
     public function getDevice()
     {
         return $this->device;
-    }
-
-    /**
-     * Sets the device name.
-     *
-     * @param string $device The device name
-     */
-    public function setDevice($device)
-    {
-        $this->device = $device;
     }
 
     /**
@@ -271,13 +243,13 @@ class UserAgent
      *
      * @param array $data The data array
      */
-    public function fromArray(array $data)
+    private function fromArray(array $data)
     {
-        $this->setBrowserName($data['browser_name']);
-        $this->setBrowserVersion($data['browser_version']);
-        $this->setBrowserEngine($data['browser_engine']);
-        $this->setOperatingSystem($data['operating_system']);
-        $this->setDevice($data['device']);
+        $this->browserName = $data['browser_name'];
+        $this->browserVersion = $data['browser_version'];
+        $this->browserEngine = $data['browser_engine'];
+        $this->operatingSystem = $data['operating_system'];
+        $this->device = $data['device'];
     }
 
     /**

--- a/lib/UserAgent.php
+++ b/lib/UserAgent.php
@@ -71,7 +71,7 @@ class UserAgent
      */
     public static function createFromGlobal()
     {
-        return new self($_SERVER['HTTP_USER_AGENT']);
+        return new self();
     }
 
     /**

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -25,7 +25,7 @@ class UserAgentTest extends \PHPUnit_Framework_TestCase
     public function testBrowserUserAgentString()
     {
         $userAgentString = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36';
-        $userAgent = new UserAgent($userAgentString);
+        $userAgent = UserAgent::create($userAgentString);
 
         $this->assertEquals('chrome', $userAgent->getBrowserName(), 'Browser: $userAgent->getBrowserName() works');
         $this->assertEquals('41.0', $userAgent->getBrowserVersion(), 'Browser: $userAgent->getBrowserVersion() works');
@@ -38,7 +38,7 @@ class UserAgentTest extends \PHPUnit_Framework_TestCase
     public function testBotUserAgentString()
     {
         $userAgentString = 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)';
-        $userAgent = new UserAgent($userAgentString);
+        $userAgent = UserAgent::create($userAgentString);
 
         $this->assertEquals('bingbot', $userAgent->getBrowserName(), 'Bot: $userAgent->getBrowserName() works');
         $this->assertEquals('2.0', $userAgent->getBrowserVersion(), 'Bot: $userAgent->getBrowserVersion() works');
@@ -50,7 +50,7 @@ class UserAgentTest extends \PHPUnit_Framework_TestCase
 
     public function testMalformedUserAgentString()
     {
-        $userAgent = new UserAgent('hmm...');
+        $userAgent = UserAgent::create('hmm...');
 
         $this->assertEquals(null, $userAgent->getBrowserName(), 'Malformed: $userAgent->getBrowserName() works');
         $this->assertEquals(null, $userAgent->getBrowserVersion(), 'Malformed: $userAgent->getBrowserVersion() works');
@@ -63,7 +63,7 @@ class UserAgentTest extends \PHPUnit_Framework_TestCase
     public function testToArray()
     {
         $userAgentString = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36';
-        $userAgent = new UserAgent($userAgentString);
+        $userAgent = UserAgent::create($userAgentString);
 
         $expected = array(
             'browser_name'     => 'chrome',


### PR DESCRIPTION
As proposed by /u/akeniscool:

```
I think the flow and the resulting API is more complicated than it needs to be, blending together the parsing/factory portion of the library with the resulting UserAgent entity. I would rather see something like a static factory that is explicit about what data is being parsed:
$userAgent = UserAgentParser::parse($_SERVER['HTTP_USER_AGENT']);

// Equivalent default, yet still explicit.
$userAgent = UserAgentParser::parseFromGlobal();
These methods would parse the information specified, and return an immutable UserAgent entity (no setters!).
```

This PR removes all public setters from the UserAgent, makes the default constructor private and adds two methods to create immutable objects: `::create($string, $parser)` and `::createFromGlobal()`.
